### PR TITLE
Fixes issue with inclusion from XC files.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 lib_xcore_math change log
 =========================
 
+2.0.1
+-----
+
+* Bugfix: Fixed issue with including ``xmath/xmath.h`` from XC files.
+* Doc Update: Corrected instructions for configuring CMake using XS3 toolchain.
+
+
 2.0.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ to manage build configurations. To configure your CMake build environment for ``
 from the root of the cloned repository, the following command may be used (ensure that the XTC build
 tools are on your path): ::
 
-    mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=../etc/xmos_toolchain.cmake -G"Unix Makefiles" ..
+    mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=../etc/xmos_cmake_toolchain/xs3a.cmake -G"Unix Makefiles" ..
 
 Then to actually build the the library as a static binary just use the ``make`` command from the 
 ``build`` directory.
@@ -81,7 +81,7 @@ Then to actually build the the library as a static binary just use the ``make`` 
 To include the unit tests and example applications in your build, use the following command
 instead: ::
 
-    mkdir build && cd build && cmake -DDEV_LIB_XCORE_MATH=1 -DCMAKE_TOOLCHAIN_FILE=../etc/xmos_toolchain.cmake -G"Unix Makefiles" ..
+    mkdir build && cd build && cmake -DDEV_LIB_XCORE_MATH=1 -DCMAKE_TOOLCHAIN_FILE=../etc/xmos_cmake_toolchain/xs3a.cmake -G"Unix Makefiles" ..
 
 If you wish to include ``lib_xcore_math`` in your own application as a static library, the generated
 ``lib_xcore_math.a`` can then be linked into your own application. Be sure to also add

--- a/lib_xcore_math/api/xmath/dct.h
+++ b/lib_xcore_math/api/xmath/dct.h
@@ -50,7 +50,7 @@ static const exponent_t dct8_exp = 4;
  * 
  * @ingroup dct_api
  */
-static const exponent_t dct12_exp = dct6_exp + 3;
+static const exponent_t dct12_exp = 7;
 
 /**
  * @brief Scaling exponent associated with `dct16_forward()`
@@ -62,7 +62,7 @@ static const exponent_t dct12_exp = dct6_exp + 3;
  * 
  * @ingroup dct_api
  */
-static const exponent_t dct16_exp = dct8_exp + 3;
+static const exponent_t dct16_exp = 7;
 
 /**
  * @brief Scaling exponent associated with `dct24_forward()`
@@ -74,7 +74,7 @@ static const exponent_t dct16_exp = dct8_exp + 3;
  * 
  * @ingroup dct_api
  */
-static const exponent_t dct24_exp = dct12_exp + 3;
+static const exponent_t dct24_exp = 10;
 
 /**
  * @brief Scaling exponent associated with `dct32_forward()`
@@ -86,7 +86,7 @@ static const exponent_t dct24_exp = dct12_exp + 3;
  * 
  * @ingroup dct_api
  */
-static const exponent_t dct32_exp = dct16_exp + 3;
+static const exponent_t dct32_exp = 10;
 
 /**
  * @brief Scaling exponent associated with `dct48_forward()`
@@ -98,7 +98,7 @@ static const exponent_t dct32_exp = dct16_exp + 3;
  * 
  * @ingroup dct_api
  */
-static const exponent_t dct48_exp = dct24_exp + 3;
+static const exponent_t dct48_exp = 13;
 
 /**
  * @brief Scaling exponent associated with `dct64_forward()`
@@ -110,7 +110,7 @@ static const exponent_t dct48_exp = dct24_exp + 3;
  * 
  * @ingroup dct_api
  */
-static const exponent_t dct64_exp = dct32_exp + 3;
+static const exponent_t dct64_exp = 13;
 
 
 /**

--- a/lib_xcore_math/api/xmath/types.h
+++ b/lib_xcore_math/api/xmath/types.h
@@ -7,9 +7,9 @@
 
 #include "api.h"
 
-
-
-
+#ifdef __XC__
+extern "C" { 
+#endif
 
 /**
  * @defgroup type_scalar_int      xmath Scalar Types (Integer)
@@ -522,3 +522,8 @@ typedef q1_31 sbrad_t;
  * @ingroup type_scalar_fixed
  */
 typedef q8_24 radian_q24_t;
+
+
+#ifdef __XC__
+} 
+#endif

--- a/test/xs3_tests/src/dummy.xc
+++ b/test/xs3_tests/src/dummy.xc
@@ -1,0 +1,14 @@
+
+
+// This file is here to close the loop on issue #106 (https://github.com/xmos/lib_xcore_math/issues/106)
+// #106 found that if "xmath/xmath.h" is included from an XC file there are compilation errors 
+// because of differences between the C/C++ behavior and XC behavior.
+
+
+// In the future if similar errors are made in this library, this file should have compilation
+// errors and we'll know early. 
+// I've confirmed that, prior to fixing #106) I do see this build error with this file.
+
+#include "xmath/xmath.h"
+
+unsigned dummy_val = 0;


### PR DESCRIPTION

This PR addresses #104 and #106.

Prior to this PR, there were errors when `xmath/xmath.h` is included from an XC file.