### PR TITLE
Fix for issue #128

### DIFF
--- a/lib_xcore_math/src/arch/xs3/filter/filter_fir_s32.S
+++ b/lib_xcore_math/src/arch/xs3/filter/filter_fir_s32.S
@@ -114,13 +114,13 @@ FUNCTION_NAME:
     {   add state_B, state_B, tmp2              ;   vldc r10[0]                             }
     {   add coef_B, coef_B, tmp2                ;   vlmaccr coef_B[0]                       }
 
-
 // Now, go back through and do full vectors.
-
 
 #undef tmp2
 #define _32     r8
 
+    bu .L_part_A_start
+    .align 16
     .L_part_A_start:
         {   ldc _32, 32                             ;   bf N_A, .L_part_A_end                   }
         .L_part_A_loop_top:

--- a/lib_xcore_math/src/arch/xs3/vect_f32/vect_f32_to_s32.S
+++ b/lib_xcore_math/src/arch/xs3/vect_f32/vect_f32_to_s32.S
@@ -53,25 +53,25 @@ FUNC_NAME:
     stw mant0, a[r11]
 
 .L_pre_loop:
-  { sub len, len, 1             ; bf len, .loop_end           }
+  { sub len, len, 1             ; bf len, .L_loop_end         }
 
-  .loop:
+  .L_loop:
       ldd mant1, mant0, b[len]
       fsexp r11, tmp, mant1
       fmant mant1, mant1
-    { sub tmp, tmp, exp           ; bf r11, .not3               }
+    { sub tmp, tmp, exp           ; bf r11, .L_not3             }
       neg mant1, mant1
-    .not3:
+    .L_not3:
         shl mant1, mant1, tmp
         fsexp r11, tmp, mant0
         fmant mant0, mant0
-      { sub tmp, tmp, exp           ; bf r11, .not4               }
+      { sub tmp, tmp, exp           ; bf r11, .L_not4             }
         neg mant0, mant0
-    .not4:
+    .L_not4:
         shl mant0, mant0, tmp
         std mant1, mant0, a[len]
-      { sub len, len, 1             ; bt  len, .loop              }
-  .loop_end:
+      { sub len, len, 1             ; bt  len, .L_loop            }
+  .L_loop_end:
 
 
       ldd r4, r5, sp[0]

--- a/lib_xcore_math/src/arch/xs3/vect_s32/vect_s32_to_f32.S
+++ b/lib_xcore_math/src/arch/xs3/vect_s32/vect_s32_to_f32.S
@@ -45,29 +45,30 @@ FUNC_NAME:
     
     ldd tmp1, tmp0, b[len]
     { lss r11, tmp0, _0           ; shl tmp1, len, 1            }
-    bf r11, .posT
+    bf r11, .L_posT
       neg tmp0, tmp0
-    .posT:
+    .L_posT:
     fmake tmp0, r11, b_exp, _0, tmp0
     stw tmp0, a[tmp1]
 
   .L_pre_loop:
 
   { sub len, len, 1               ; bf len, .L_loop_end           }
-  .loop:
+  
+  .L_loop:
     ldd tmp1, tmp0, b[len]
   { lss r11, tmp1, _0             ;                               }
-    bf r11, .pos1
+    bf r11, .L_pos1
       neg tmp1, tmp1
-    .pos1:
+    .L_pos1:
     fmake tmp1, r11, b_exp, _0, tmp1
     lss r11, tmp0, _0
-    bf r11, .pos0
+    bf r11, .L_pos0
       neg tmp0, tmp0
-    .pos0:
+    .L_pos0:
     fmake tmp0, r11, b_exp, _0, tmp0
     std tmp1, tmp0, a[len]
-    { sub len, len, 1             ; bt len, .loop                 }
+    { sub len, len, 1             ; bt len, .L_loop               }
   .L_loop_end:
     
     ldd r4, r5, sp[0]


### PR DESCRIPTION
This PR addresses issue #128. It should not change the functional behavior at all, but should speed up the 32-bit FIR filter by avoiding FNOPs.

There is also a small change to the float vector / BFP conversion assembly functions. Previously they were using non-local labels for branch targets, now they're using local labels. 

(A local label is one prefixed with `.L`. Local labels do not become global symbols, so they cannot collide with labels from other files. This also ensures that in a disassembly (`xobjdump -D`) or the debugger the addresses of instructions are shown relative to the function start (which is the actual reason I originally made the change, as it was confusing when I was trying to trace program behavior))