### PR TITLE
Now using officially supported xcore_builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Pull builder container
         run: |
-          docker pull ghcr.io/xmos/sdk_app_builder:develop 
+          docker pull ghcr.io/xmos/xcore_builder:latest
 
       - name: Install Python
         uses: actions/setup-python@v2
@@ -51,7 +51,7 @@ jobs:
       - name: Build
         run: |
           mkdir ~/artifacts
-          docker run --rm -w /lib_xcore_math -v ${{ github.workspace }}:/lib_xcore_math -v ~/artifacts:/artifacts ghcr.io/xmos/sdk_app_builder:develop bash -l .github/scripts/build_tests_xcore.sh
+          docker run --rm -w /lib_xcore_math -v ${{ github.workspace }}:/lib_xcore_math -v ~/artifacts:/artifacts ghcr.io/xmos/xcore_builder:latest bash -l .github/scripts/build_tests_xcore.sh
 
       - name: Save Unit Test Artifacts
         uses: actions/upload-artifact@v2
@@ -120,7 +120,7 @@ jobs:
 
       - name: Pull builder container
         run: |
-          docker pull ghcr.io/xmos/sdk_app_builder:develop 
+          docker pull ghcr.io/xmos/xcore_builder:latest 
 
       - name: Install Python
         uses: actions/setup-python@v2
@@ -134,4 +134,4 @@ jobs:
 
       - name: Build
         run: |
-          docker run --rm -w /lib_xcore_math -v ${{ github.workspace }}:/lib_xcore_math ghcr.io/xmos/sdk_app_builder:develop bash -l .github/scripts/build_legacy.sh
+          docker run --rm -w /lib_xcore_math -v ${{ github.workspace }}:/lib_xcore_math ghcr.io/xmos/xcore_builder:latest bash -l .github/scripts/build_legacy.sh


### PR DESCRIPTION
This PR updates the Docker image to the latest, officially supported https://github.com/xmos/xcore_builder

The sdk_app_builder image will remain available for pulling but it is no longer supported.  
