### PR TITLE
Don't link to githubs #readme anchor

### DIFF
--- a/doc/programming_guide/src/getting_started.rst
+++ b/doc/programming_guide/src/getting_started.rst
@@ -56,7 +56,7 @@ Building
 --------
 
 This library makes use of the CMake build system. See the 
-`GitHub page <https://github.com/xmos/lib_xcore_math#readme>`_ for instructions on obtaining this
+`GitHub readme <https://github.com/xmos/lib_xcore_math>`_ for instructions on obtaining this
 library's source code and including it in your application's build.
 
 Usage


### PR DESCRIPTION
This has broken in linkcheck from underneath us, suggesting that github renders this anchor on the fly.

example of failure: http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_xcore_math/detail/develop/88/pipeline/59