### PR TITLE
Fix for all resource allocation changes

### DIFF
--- a/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_dot.S
+++ b/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_dot.S
@@ -34,10 +34,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_log.S
+++ b/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_log.S
@@ -159,10 +159,10 @@ xm.retsp (NSTACKWORDS)*4
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #endif //defined(__VX4B__)

--- a/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_power_series.S
+++ b/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_power_series.S
@@ -69,10 +69,10 @@ xm.retsp (NSTACKWORDS)*4
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_power_series_v2.S
+++ b/lib_xcore_math/src/arch/vx4b/chunk_s32/chunk_s32_power_series_v2.S
@@ -90,10 +90,10 @@ xm.retsp (NSTACKWORDS)*4
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct12_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct12_s32.S
@@ -118,14 +118,10 @@ xm.stdi  a,d, 40(left)
 xm.lddsp  s3,s2,0
 { nop                                   ; xm.retsp (NSTACKWORDS)*4              }
 
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct16_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct16_s32.S
@@ -138,14 +138,10 @@ la t3, vpu_vec_0x20000000
 
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct24_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct24_s32.S
@@ -160,14 +160,10 @@ la t3, dct12_forward
 
 
 	
-.set	FUNCTION_NAME.nstackwords,(NSTACKWORDS+12)
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", ((NSTACKWORDS+12))*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct6_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct6_s32.S
@@ -46,14 +46,10 @@ la t3, dct6_matrix
 xm.vstrpv y, mask
 { nop                                   ; xm.retsp (NSTACKWORDS)*4              }
 
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct8_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct8_s32.S
@@ -48,14 +48,10 @@ xm.vlsat t3
 { xm.zexti t3, 5                        ; nop                                   }
 { sub a0, a0, t3                        ; xm.retsp (NSTACKWORDS)*4              }
 
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct_adsb_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct_adsb_s32.S
@@ -61,14 +61,10 @@ xm.lddsp  s3,s2,0
 { sub a0, a0, t3                        ; xm.retsp (NSTACKWORDS)*4              }
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/dct_deconvolve_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/dct_deconvolve_s32.S
@@ -66,14 +66,10 @@ xm.lddsp  s5,s4,8
 xm.lddsp  s3,s2,0  
 xm.retsp (NSTACKWORDS)*4  
 
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/idct6_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/idct6_s32.S
@@ -48,14 +48,10 @@ xm.vstrpv y, mask
 
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/idct8_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/idct8_s32.S
@@ -49,14 +49,10 @@ xm.vlsat t3
 { nop                                   ; xm.retsp (NSTACKWORDS)*4              }
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/idct_adsb.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/idct_adsb.S
@@ -55,14 +55,10 @@ FUNCTION_NAME:
   xm.retsp (NSTACKWORDS)*4
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/idct_convolve.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/idct_convolve.S
@@ -65,14 +65,10 @@ FUNCTION_NAME:
   xm.retsp (NSTACKWORDS)*4
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s32/idct_scale.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s32/idct_scale.S
@@ -49,14 +49,10 @@ FUNCTION_NAME:
   xm.retsp (NSTACKWORDS)*4
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s8/dct8x8_stageA.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s8/dct8x8_stageA.S
@@ -170,14 +170,10 @@ la t3, .L_sat_vec
 { sub a0, a0, t3                        ; xm.retsp (NSTACKWORDS)*4              }
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/s8/dct8x8_stageB.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/s8/dct8x8_stageB.S
@@ -176,14 +176,10 @@ xm.zip t3, a3, 4
 { sub a0, a0, t3                        ; xm.retsp (NSTACKWORDS)*4              }
 
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/dct/vect_s32_flip.S
+++ b/lib_xcore_math/src/arch/vx4b/dct/vect_s32_flip.S
@@ -36,14 +36,10 @@ xm.entsp (NSTACKWORDS)*4
 .L_loop_bottom:
 xm.retsp (NSTACKWORDS)*4  
 	
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/fft/dif_fft.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/dif_fft.S
@@ -141,14 +141,10 @@ dif_fft_done:
 
 	xm.retsp (NSTACKWORDS)*4
 
-	.set	fft_dif_forward.nstackwords,NSTACKWORDS
-	.globl	fft_dif_forward.nstackwords
-	.set	fft_dif_forward.maxcores,1
-	.globl	fft_dif_forward.maxcores
-	.set	fft_dif_forward.maxtimers,0
-	.globl	fft_dif_forward.maxtimers
-	.set	fft_dif_forward.maxchanends,0
-	.globl	fft_dif_forward.maxchanends
+.resource_const fft_dif_forward, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty fft_dif_forward, "tail_callees"
+.resource_list_empty fft_dif_forward, "callees"
+.resource_list_empty fft_dif_forward, "parallel_callees"
 .L_fft_dif_forward:
 	.size	fft_dif_forward, .L_fft_dif_forward-fft_dif_forward
 
@@ -257,14 +253,10 @@ dif_ifft_done:
     
 	 xm.retsp (NSTACKWORDS)*4
 
-	.set	fft_dif_inverse.nstackwords,NSTACKWORDS
-	.globl	fft_dif_inverse.nstackwords
-	.set	fft_dif_inverse.maxcores,1
-	.globl	fft_dif_inverse.maxcores
-	.set	fft_dif_inverse.maxtimers,0
-	.globl	fft_dif_inverse.maxtimers
-	.set	fft_dif_inverse.maxchanends,0
-	.globl	fft_dif_inverse.maxchanends
+.resource_const fft_dif_inverse, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty fft_dif_inverse, "tail_callees"
+.resource_list_empty fft_dif_inverse, "callees"
+.resource_list_empty fft_dif_inverse, "parallel_callees"
 .L_fft_dif_inverse:
 	.size	fft_dif_inverse, .L_fft_dif_inverse-fft_dif_inverse
 

--- a/lib_xcore_math/src/arch/vx4b/fft/dit_fft.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/dit_fft.S
@@ -162,14 +162,10 @@ xm.lddsp  s6,s5,16
 xm.lddsp  s8,s7,24
 xm.retsp (NSTACKWORDS)*4
     
-    .set	    fft_dit_forward.nstackwords,NSTACKWORDS
-    .globl	    fft_dit_forward.nstackwords
-    .set	    fft_dit_forward.maxcores,1
-    .globl	    fft_dit_forward.maxcores
-    .set	    fft_dit_forward.maxtimers,0
-    .globl	    fft_dit_forward.maxtimers
-    .set	    fft_dit_forward.maxchanends,0
-    .globl	    fft_dit_forward.maxchanends
+.resource_const fft_dit_forward, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty fft_dit_forward, "tail_callees"
+.resource_list_empty fft_dit_forward, "callees"
+.resource_list_empty fft_dit_forward, "parallel_callees"
 
 .Ltmp0:
     .size	fft_dit_forward, .Ltmp0-fft_dit_forward
@@ -285,14 +281,10 @@ xm.lddsp  s6,s5,16
 xm.lddsp  s8,s7,24
 xm.retsp (NSTACKWORDS)*4   
 
-    .set	    fft_dit_inverse.nstackwords,NSTACKWORDS
-    .globl	    fft_dit_inverse.nstackwords
-    .set	    fft_dit_inverse.maxcores,1
-    .globl	    fft_dit_inverse.maxcores
-    .set	    fft_dit_inverse.maxtimers,0
-    .globl	    fft_dit_inverse.maxtimers
-    .set	    fft_dit_inverse.maxchanends,0
-    .globl	    fft_dit_inverse.maxchanends
+.resource_const fft_dit_inverse, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty fft_dit_inverse, "tail_callees"
+.resource_list_empty fft_dit_inverse, "callees"
+.resource_list_empty fft_dit_inverse, "parallel_callees"
 .Ltmp1:
     .size	fft_dit_inverse, .Ltmp1-fft_dit_inverse
 

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_index_bit_reversal.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_index_bit_reversal.S
@@ -4,7 +4,6 @@
 #if defined(__VX4B__)
 
 /*  
-
 void fft_index_bit_reversal(
     complex_s32_t* a,
     const unsigned length);

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_index_bit_reversal.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_index_bit_reversal.S
@@ -51,14 +51,10 @@ xm.lddsp  s2, s3, 8
 xm.retsp (NSTACKWORDS)*4
 
 	// RETURN_REG_HOLDER
-.set	FUNCTION_NAME.nstackwords,NSTACKWORDS
-.globl	FUNCTION_NAME.nstackwords
-.set	FUNCTION_NAME.maxcores,1
-.globl	FUNCTION_NAME.maxcores
-.set	FUNCTION_NAME.maxtimers,0
-.globl	FUNCTION_NAME.maxtimers
-.set	FUNCTION_NAME.maxchanends,0
-.globl	FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNCTION_NAME, .Ltmp0-FUNCTION_NAME    
 

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_mono_adjust.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_mono_adjust.S
@@ -196,11 +196,11 @@ FUNCTION_NAME:
     xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,((NSTACKWORDS) + vect_complex_s32_tail_reverse.nstackwords);
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (((NSTACKWORDS))*4
 .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 
 .L_function_end: 
     .size FUNCTION_NAME, .L_function_end - FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_mono_adjust.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_mono_adjust.S
@@ -195,11 +195,9 @@ FUNCTION_NAME:
     xm.lddsp  s6,s7,24
     xm.retsp (NSTACKWORDS)*4
 
-//.cc_bottom FUNCTION_NAME.function; 
-.resource_const FUNCTION_NAME, "stack_frame_bytes", (((NSTACKWORDS))*4
-.global FUNCTION_NAME.nstackwords; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", ( ((NSTACKWORDS)))*4
 .resource_list_empty FUNCTION_NAME, "tail_callees"
-.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_add   FUNCTION_NAME, "callees", vect_complex_s32_tail_reverse
 .resource_list_empty FUNCTION_NAME, "parallel_callees"
 
 .L_function_end: 

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_merge.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_merge.S
@@ -142,11 +142,11 @@ la t3, vpu_vec_complex_conj_op
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS + vect_complex_s32_tail_reverse.nstackwords;     
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
                                                 .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_function_end: 
     .size FUNCTION_NAME, .L_function_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_merge.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_merge.S
@@ -141,9 +141,7 @@ la t3, vpu_vec_complex_conj_op
         xm.lddsp  s7,s6,0
         xm.retsp (NSTACKWORDS)*4
 
-//.cc_bottom FUNCTION_NAME.function; 
 .resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
-                                                .global FUNCTION_NAME.nstackwords; 
 .resource_list_empty FUNCTION_NAME, "tail_callees"
 .resource_list_empty FUNCTION_NAME, "callees"
 .resource_list_empty FUNCTION_NAME, "parallel_callees"

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_split.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_split.S
@@ -131,11 +131,11 @@ FUNCTION_NAME:
     xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS + vect_complex_s32_tail_reverse.nstackwords;     
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
                                                 .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_function_end: 
     .size FUNCTION_NAME, .L_function_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_split.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/fft_spectra_split.S
@@ -130,9 +130,7 @@ FUNCTION_NAME:
     xm.lddsp  s7,s6,0
     xm.retsp (NSTACKWORDS)*4
 
-//.cc_bottom FUNCTION_NAME.function; 
 .resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
-                                                .global FUNCTION_NAME.nstackwords; 
 .resource_list_empty FUNCTION_NAME, "tail_callees"
 .resource_list_empty FUNCTION_NAME, "callees"
 .resource_list_empty FUNCTION_NAME, "parallel_callees"

--- a/lib_xcore_math/src/arch/vx4b/fft/tail_reverse_complex_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/fft/tail_reverse_complex_s32.S
@@ -88,10 +88,10 @@ FUNCTION_NAME:
     xm.lddsp  s7,s6,0
     xm.retsp (NSTACKWORDS)*4
 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;  .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;               .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;              .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;            .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_func_end:
     .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/filter_biquad_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/filter_biquad_s32.S
@@ -139,10 +139,10 @@ la t3, vpu_vec_zero
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_size_end:
     .size FUNCTION_NAME, .L_size_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/filter_biquad_sat_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/filter_biquad_sat_s32.S
@@ -205,10 +205,10 @@ li N, (0)
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_size_end:
     .size FUNCTION_NAME, .L_size_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/filter_fir_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/filter_fir_s16.S
@@ -111,9 +111,7 @@ FUNCTION_NAME:
         xm.lddsp  s3,s2,8
         xm.retsp (NSTACKWORDS)*4
 
-//.cc_bottom FUNCTION_NAME.function; 
 .resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
-.global FUNCTION_NAME.nstackwords; 
 .resource_list_empty FUNCTION_NAME, "tail_callees"
 .resource_list_empty FUNCTION_NAME, "callees"
 .resource_list_empty FUNCTION_NAME, "parallel_callees"

--- a/lib_xcore_math/src/arch/vx4b/filter/filter_fir_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/filter_fir_s16.S
@@ -112,11 +112,11 @@ FUNCTION_NAME:
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS + filter_fir_s16_push_sample_up.nstackwords;     
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_size_end:
     .size FUNCTION_NAME, .L_size_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/filter_fir_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/filter_fir_s32.S
@@ -188,10 +188,10 @@ FUNCTION_NAME:
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_size_end:
     .size FUNCTION_NAME, .L_size_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/push_sample_down_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/push_sample_down_s16.S
@@ -110,10 +110,10 @@ FUNCTION_NAME:
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_size_end:
     .size FUNCTION_NAME, .L_size_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/push_sample_up_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/push_sample_up_s16.S
@@ -135,10 +135,10 @@ FUNCTION_NAME:
         xm.retsp (NSTACKWORDS)*4
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_size_end:
     .size FUNCTION_NAME, .L_size_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/filter/vect_s32_convolve_valid.S
+++ b/lib_xcore_math/src/arch/vx4b/filter/vect_s32_convolve_valid.S
@@ -116,10 +116,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/matrix/mat_mul_s8_x_s8_yield_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/matrix/mat_mul_s8_x_s8_yield_s32.S
@@ -113,10 +113,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/misc/chunk_float_s32_log.S
+++ b/lib_xcore_math/src/arch/vx4b/misc/chunk_float_s32_log.S
@@ -171,10 +171,10 @@ la t3, vpu_vec_0x7FFFFFFF
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/misc/util.S
+++ b/lib_xcore_math/src/arch/vx4b/misc/util.S
@@ -44,10 +44,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS
@@ -90,10 +90,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_pack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/misc/vect_copy.S
+++ b/lib_xcore_math/src/arch/vx4b/misc/vect_copy.S
@@ -51,10 +51,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;  .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;               .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;              .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;            .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 
 
 #endif //defined(__VX4B__)

--- a/lib_xcore_math/src/arch/vx4b/misc/vect_float_s32_ln_prepare.S
+++ b/lib_xcore_math/src/arch/vx4b/misc/vect_float_s32_ln_prepare.S
@@ -108,10 +108,10 @@ la t3, .L_32_Q24
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/misc/xs3_memcpy.S
+++ b/lib_xcore_math/src/arch/vx4b/misc/xs3_memcpy.S
@@ -44,10 +44,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;  .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;               .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;              .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;            .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 
 
 #endif //defined(__VX4B__)

--- a/lib_xcore_math/src/arch/vx4b/scalar/f32_log2.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/f32_log2.S
@@ -50,12 +50,12 @@ la t3, f32_power_series
 .add_to_set FUNCTION_NAME.callees,f32_normA.nstackwords
 .add_to_set FUNCTION_NAME.callees,f32_power_series.nstackwords
 .max_reduce FUNCTION_NAME.callee_maxstackwords,FUNCTION_NAME.callees,0
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS+FUNCTION_NAME.callee_maxstackwords
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS+FUNCTION_NAME)*4
 .global FUNCTION_NAME.nstackwords
 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/scalar/f32_log2.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/f32_log2.S
@@ -46,15 +46,10 @@ la t3, f32_power_series
 .type FUNCTION_NAME,@function
 
 
-.weak FUNCTION_NAME.callees
-.add_to_set FUNCTION_NAME.callees,f32_normA.nstackwords
-.add_to_set FUNCTION_NAME.callees,f32_power_series.nstackwords
-.max_reduce FUNCTION_NAME.callee_maxstackwords,FUNCTION_NAME.callees,0
-.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS+FUNCTION_NAME)*4
-.global FUNCTION_NAME.nstackwords
-
+.resource_const FUNCTION_NAME, "stack_frame_bytes", ( ((NSTACKWORDS)))*4
+.resource_list_add   FUNCTION_NAME, "callees", f32_normA
+.resource_list_add   FUNCTION_NAME, "callees", f32_power_series
 .resource_list_empty FUNCTION_NAME, "tail_callees"
-.resource_list_empty FUNCTION_NAME, "callees"
 .resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/f32_norm.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/f32_norm.S
@@ -31,10 +31,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/scalar/f32_power_series.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/f32_power_series.S
@@ -120,10 +120,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/f32_sin.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/f32_sin.S
@@ -124,10 +124,10 @@ PS_TERM(7)
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/q24_logistic_fast.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/q24_logistic_fast.S
@@ -63,10 +63,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/scalar/q30_exp_small.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/q30_exp_small.S
@@ -97,10 +97,10 @@ la t3, .L_ps_neg_q30
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/scalar/q30_odd_powers.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/q30_odd_powers.S
@@ -57,10 +57,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/scalar/q30_powers.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/q30_powers.S
@@ -93,10 +93,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end_unpack - FUNCTION_NAME
 
 #undef NSTACKWORDS

--- a/lib_xcore_math/src/arch/vx4b/scalar/radians_to_sbrads.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/radians_to_sbrads.S
@@ -73,10 +73,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/sbrad_sin.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/sbrad_sin.S
@@ -96,10 +96,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/sbrad_tan.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/sbrad_tan.S
@@ -128,10 +128,10 @@ xm.vlsat t3
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s16.S
@@ -21,16 +21,11 @@
 
 
 #define FUNC_END                                \
-.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
-    .global FUNCTION_NAME.nstackwords;      \
-.resource_list_empty FUNCTION_NAME, "tail_callees"
-    .global FUNCTION_NAME.maxcores;         \
-.resource_list_empty FUNCTION_NAME, "callees"
-    .global FUNCTION_NAME.maxtimers;        \
-.resource_list_empty FUNCTION_NAME, "parallel_callees"
-    .global FUNCTION_NAME.maxchanends;      \
-    CAT(.L_size_end_, FUNCTION_NAME):              \
-    .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4 ;\
+.resource_list_empty FUNCTION_NAME, "tail_callees" ;\
+.resource_list_empty FUNCTION_NAME, "callees" ;\
+.resource_list_empty FUNCTION_NAME, "parallel_callees" ;\
+.size FUNCTION_NAME, . - FUNCTION_NAME
 
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s16.S
@@ -21,13 +21,13 @@
 
 
 #define FUNC_END                                \
-    .set FUNCTION_NAME.nstackwords,NSTACKWORDS;   \
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
     .global FUNCTION_NAME.nstackwords;      \
-    .set FUNCTION_NAME.maxcores,1;                 \
+.resource_list_empty FUNCTION_NAME, "tail_callees"
     .global FUNCTION_NAME.maxcores;         \
-    .set FUNCTION_NAME.maxtimers,0;                \
+.resource_list_empty FUNCTION_NAME, "callees"
     .global FUNCTION_NAME.maxtimers;        \
-    .set FUNCTION_NAME.maxchanends,0;              \
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
     .global FUNCTION_NAME.maxchanends;      \
     CAT(.L_size_end_, FUNCTION_NAME):              \
     .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME
@@ -67,10 +67,10 @@ FUNCTION_NAME:
 FUNC_END
 
 // //.cc_bottom FUNCTION_NAME.function; 
-// .set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords; 
-// .set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores; 
-// .set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers; 
-// .set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends; 
+//.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+//.resource_list_empty FUNCTION_NAME, "tail_callees"
+//.resource_list_empty FUNCTION_NAME, "callees"
+//.resource_list_empty FUNCTION_NAME, "parallel_callees"
 
 // CAT(.L_size_end_, FUNCTION_NAME): 
 //     .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s32.S
@@ -20,16 +20,12 @@
 
 
 #define FUNC_END                                \
-.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
-    .global FUNCTION_NAME.nstackwords;      \
-.resource_list_empty FUNCTION_NAME, "tail_callees"
-    .global FUNCTION_NAME.maxcores;         \
-.resource_list_empty FUNCTION_NAME, "callees"
-    .global FUNCTION_NAME.maxtimers;        \
-.resource_list_empty FUNCTION_NAME, "parallel_callees"
-    .global FUNCTION_NAME.maxchanends;      \
-    CAT(.L_size_end_, FUNCTION_NAME):              \
-    .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4 ;\
+.resource_list_empty FUNCTION_NAME, "tail_callees" ;\
+.resource_list_empty FUNCTION_NAME, "callees" ;\
+.resource_list_empty FUNCTION_NAME, "parallel_callees" ;\
+.size FUNCTION_NAME, . - FUNCTION_NAME
+
 
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s32.S
@@ -20,13 +20,13 @@
 
 
 #define FUNC_END                                \
-    .set FUNCTION_NAME.nstackwords,NSTACKWORDS;   \
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
     .global FUNCTION_NAME.nstackwords;      \
-    .set FUNCTION_NAME.maxcores,1;                 \
+.resource_list_empty FUNCTION_NAME, "tail_callees"
     .global FUNCTION_NAME.maxcores;         \
-    .set FUNCTION_NAME.maxtimers,0;                \
+.resource_list_empty FUNCTION_NAME, "callees"
     .global FUNCTION_NAME.maxtimers;        \
-    .set FUNCTION_NAME.maxchanends,0;              \
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
     .global FUNCTION_NAME.maxchanends;      \
     CAT(.L_size_end_, FUNCTION_NAME):              \
     .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s8.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s8.S
@@ -20,13 +20,13 @@
 
 
 #define FUNC_END                                \
-    .set FUNCTION_NAME.nstackwords,NSTACKWORDS;   \
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
     .global FUNCTION_NAME.nstackwords;      \
-    .set FUNCTION_NAME.maxcores,1;                 \
+.resource_list_empty FUNCTION_NAME, "tail_callees"
     .global FUNCTION_NAME.maxcores;         \
-    .set FUNCTION_NAME.maxtimers,0;                \
+.resource_list_empty FUNCTION_NAME, "callees"
     .global FUNCTION_NAME.maxtimers;        \
-    .set FUNCTION_NAME.maxchanends,0;              \
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
     .global FUNCTION_NAME.maxchanends;      \
     CAT(.L_size_end_, FUNCTION_NAME):              \
     .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME
@@ -68,10 +68,10 @@ FUNCTION_NAME:
 FUNC_END
 
 // //.cc_bottom FUNCTION_NAME.function; 
-// .set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords; 
-// .set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores; 
-// .set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers; 
-// .set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends; 
+//.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+//.resource_list_empty FUNCTION_NAME, "tail_callees"
+//.resource_list_empty FUNCTION_NAME, "callees"
+//.resource_list_empty FUNCTION_NAME, "parallel_callees"
 
 // CAT(.L_size_end_, FUNCTION_NAME): 
 //     .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s8.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/scalar_op_s8.S
@@ -20,16 +20,12 @@
 
 
 #define FUNC_END                                \
-.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
-    .global FUNCTION_NAME.nstackwords;      \
-.resource_list_empty FUNCTION_NAME, "tail_callees"
-    .global FUNCTION_NAME.maxcores;         \
-.resource_list_empty FUNCTION_NAME, "callees"
-    .global FUNCTION_NAME.maxtimers;        \
-.resource_list_empty FUNCTION_NAME, "parallel_callees"
-    .global FUNCTION_NAME.maxchanends;      \
-    CAT(.L_size_end_, FUNCTION_NAME):              \
-    .size FUNCTION_NAME, CAT(.L_size_end_, FUNCTION_NAME) - FUNCTION_NAME
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4 ;\
+.resource_list_empty FUNCTION_NAME, "tail_callees" ;\
+.resource_list_empty FUNCTION_NAME, "callees" ;\
+.resource_list_empty FUNCTION_NAME, "parallel_callees" ;\
+.size FUNCTION_NAME, . - FUNCTION_NAME
+
 
 
 

--- a/lib_xcore_math/src/arch/vx4b/scalar/sqrt_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/scalar/sqrt_s32.S
@@ -106,10 +106,10 @@ la t3, vpu_vec_0x80000000
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME,.L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_complex_scale.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_complex_scale.S
@@ -188,10 +188,10 @@ xm.zip s3, s2, 4
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_conj_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_conj_macc.S
@@ -203,10 +203,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_conj_nmacc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_conj_nmacc.S
@@ -195,10 +195,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_conjugate_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_conjugate_mul.S
@@ -144,10 +144,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_macc.S
@@ -196,10 +196,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_mag.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_mag.S
@@ -253,10 +253,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_mul.S
@@ -170,10 +170,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_nmacc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_nmacc.S
@@ -195,10 +195,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_real_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_real_mul.S
@@ -126,10 +126,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_squared_mag.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_squared_mag.S
@@ -104,10 +104,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_sum.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_sum.S
@@ -140,10 +140,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_to_complex_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s16/vect_complex_s16_to_complex_s32.S
@@ -48,10 +48,10 @@ FUNCTION_NAME:
     xm.retsp (NSTACKWORDS)*4       
 
     //.cc_bottom FUNCTION_NAME.function; 
-    .set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-    .set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-    .set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-    .set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
     
 .L_func_end:
     .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_complex_scale.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_complex_scale.S
@@ -135,10 +135,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conj_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conj_macc.S
@@ -113,10 +113,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conj_nmacc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conj_nmacc.S
@@ -113,10 +113,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conjugate.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conjugate.S
@@ -68,10 +68,10 @@ la t3, vpu_vec_complex_conj_op
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conjugate_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_conjugate_mul.S
@@ -100,10 +100,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_macc.S
@@ -112,10 +112,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_mag.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_mag.S
@@ -143,10 +143,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_mul.S
@@ -100,10 +100,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_nmacc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_nmacc.S
@@ -112,10 +112,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_real_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_real_mul.S
@@ -118,10 +118,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_squared_mag.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_squared_mag.S
@@ -103,10 +103,10 @@ la t3, vpu_vec_complex_ones
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_sum.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_sum.S
@@ -133,10 +133,10 @@ la t3, vpu_vec_0x40000000
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_to_complex_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_complex_s32/vect_complex_s32_to_complex_s16.S
@@ -87,10 +87,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_conj_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_conj_macc.S
@@ -64,10 +64,10 @@ FUNC_NAME:
   xm.lddsp  s7,s6,16
   xm.retsp (NSTACKWORDS)*4
     
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;     .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;                  .globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;                 .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;               .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_conj_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_conj_mul.S
@@ -68,10 +68,10 @@ FUNC_NAME:
   xm.lddsp  s7,s6,16
   xm.retsp (NSTACKWORDS)*4
     
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;     .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;                  .globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;                 .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;               .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_macc.S
@@ -64,10 +64,10 @@ FUNC_NAME:
   xm.lddsp  s7,s6,16
   xm.retsp (NSTACKWORDS)*4
     
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;     .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;                  .globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;                 .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;               .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_complex_f32_mul.S
@@ -69,10 +69,10 @@ FUNC_NAME:
   xm.lddsp  s7,s6,16
   xm.retsp (NSTACKWORDS)*4
     
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;     .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;                  .globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;                 .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;               .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_add.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_add.S
@@ -75,10 +75,10 @@ FUNC_NAME:
     
 	
 	// RETURN_REG_HOLDER
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;     .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;                  .globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;                 .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;               .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_dot.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_dot.S
@@ -105,10 +105,10 @@ FUNC_NAME:
     
 	
 	// RETURN_REG_HOLDER
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;     .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;                  .globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;                 .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;               .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_max_exponent.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_max_exponent.S
@@ -60,10 +60,10 @@ FUNC_NAME:
     xm.retsp (NSTACKWORDS)*4
 	
 	// RETURN_REG_HOLDER
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;  .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;              	.globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;              .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;            .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNC_NAME, .Ltmp0-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_to_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_f32/vect_f32_to_s32.S
@@ -78,10 +78,10 @@ FUNC_NAME:
       xm.retsp (NSTACKWORDS)*4
 	
 	// RETURN_REG_HOLDER
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS;  .globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1;              	.globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0;              .globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0;            .globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp0:
 	.size	FUNC_NAME, .Ltmp0-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_abs.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_abs.S
@@ -115,10 +115,10 @@ vect_s16_abs:
 
 .global vect_s16_abs
 .type vect_s16_abs,@function
-.set vect_s16_abs.nstackwords,NSTACKWORDS;  .global vect_s16_abs.nstackwords
-.set vect_s16_abs.maxcores,1;               .global vect_s16_abs.maxcores
-.set vect_s16_abs.maxtimers,0;              .global vect_s16_abs.maxtimers
-.set vect_s16_abs.maxchanends,0;            .global vect_s16_abs.maxchanends
+.resource_const vect_s16_abs, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s16_abs, "tail_callees"
+.resource_list_empty vect_s16_abs, "callees"
+.resource_list_empty vect_s16_abs, "parallel_callees"
 .size vect_s16_abs, .L_func_end_s16 - vect_s16_abs
 
 #endif //defined(__VX4B__)

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_abs_sum.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_abs_sum.S
@@ -135,10 +135,10 @@ FUNCTION_NAME:
     { or a0, a0, a1                     ; xm.retsp (NSTACKWORDS)*4              }
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_argmax.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_argmax.S
@@ -151,10 +151,10 @@ xm.eq tmz, a0, cur_max
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_argmin.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_argmin.S
@@ -170,10 +170,10 @@ xm.eq tmz, cur_min, a0
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_clip.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_clip.S
@@ -318,10 +318,10 @@ xm.zip s7, s6, 4
 .L_func_end:
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_energy.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_energy.S
@@ -100,10 +100,10 @@ FUNCTION_NAME:
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_extract_high_byte.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_extract_high_byte.S
@@ -116,10 +116,10 @@ la t3, vpu_vec_0x007F
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_extract_low_byte.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_extract_low_byte.S
@@ -115,10 +115,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_inverse.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_inverse.S
@@ -53,10 +53,10 @@ xm.mkmsk s2, s2
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_macc.S
@@ -108,10 +108,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_max.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_max.S
@@ -98,10 +98,10 @@ xm.zip tmz, tmp, 0
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_min.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_min.S
@@ -99,10 +99,10 @@ FUNCTION_NAME:
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_mul.S
@@ -92,10 +92,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_nmacc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_nmacc.S
@@ -108,10 +108,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_scale.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_scale.S
@@ -103,10 +103,10 @@ xm.zip t3, tmp, 4
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_sqrt.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_sqrt.S
@@ -190,10 +190,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_sum.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_sum.S
@@ -101,10 +101,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_fend - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_to_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s16/vect_s16_to_s32.S
@@ -101,10 +101,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/s32_to_chunk_s32.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/s32_to_chunk_s32.S
@@ -36,10 +36,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_abs.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_abs.S
@@ -94,10 +94,10 @@ vect_s32_abs:
 
 .global vect_s32_abs
 .type vect_s32_abs,@function
-.set vect_s32_abs.nstackwords,NSTACKWORDS;  .global vect_s32_abs.nstackwords
-.set vect_s32_abs.maxcores,1;               .global vect_s32_abs.maxcores
-.set vect_s32_abs.maxtimers,0;              .global vect_s32_abs.maxtimers
-.set vect_s32_abs.maxchanends,0;            .global vect_s32_abs.maxchanends
+.resource_const vect_s32_abs, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s32_abs, "tail_callees"
+.resource_list_empty vect_s32_abs, "callees"
+.resource_list_empty vect_s32_abs, "parallel_callees"
 .size vect_s32_abs, .L_func_end_s32 - vect_s32_abs
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_abs_sum.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_abs_sum.S
@@ -88,10 +88,10 @@ la t3, vpu_vec_zero
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_argmax.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_argmax.S
@@ -140,10 +140,10 @@ xm.zip tmz, tmp, 0
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_argmin.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_argmin.S
@@ -146,10 +146,10 @@ xm.zip tmz, tmp, 0
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_clip.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_clip.S
@@ -318,10 +318,10 @@ FUNCTION_NAME:
 .L_func_end:
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_dot.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_dot.S
@@ -104,10 +104,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_energy.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_energy.S
@@ -92,10 +92,10 @@ la t3, vpu_vec_zero
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_inverse.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_inverse.S
@@ -100,10 +100,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_macc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_macc.S
@@ -106,10 +106,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_max.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_max.S
@@ -95,10 +95,10 @@ xm.zip tmz, tmp, 0
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_merge_accs.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_merge_accs.S
@@ -91,10 +91,10 @@ xm.unzip  tmpD, tmpR, 4
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_min.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_min.S
@@ -98,10 +98,10 @@ xm.zip tmz, tmp, 0
 
 
 //.cc_bottom FUNCTION_NAME.function; 
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .L_end: 
     .size FUNCTION_NAME, .L_end - FUNCTION_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_mul.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_mul.S
@@ -96,10 +96,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_nmacc.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_nmacc.S
@@ -106,10 +106,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_scale.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_scale.S
@@ -95,10 +95,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_split_accs.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_split_accs.S
@@ -101,10 +101,10 @@ xm.zip tmpR, tmpD, 4
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_sqrt.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_sqrt.S
@@ -172,10 +172,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_sum.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_sum.S
@@ -84,10 +84,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords; 
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores; 
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers; 
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends; 
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_fend - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_to_f32.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_to_f32.S
@@ -76,14 +76,10 @@ FUNC_NAME:
 
 	
 	// RETURN_REG_HOLDER
-	.set	FUNC_NAME.nstackwords,NSTACKWORDS
-	.globl	FUNC_NAME.nstackwords
-	.set	FUNC_NAME.maxcores,1
-	.globl	FUNC_NAME.maxcores
-	.set	FUNC_NAME.maxtimers,0
-	.globl	FUNC_NAME.maxtimers
-	.set	FUNC_NAME.maxchanends,0
-	.globl	FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .Ltmp1:
 	.size	FUNC_NAME, .Ltmp1-FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_to_s16.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_to_s16.S
@@ -67,10 +67,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_unzip.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_unzip.S
@@ -56,10 +56,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_zip.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s32/vect_s32_zip.S
@@ -130,10 +130,10 @@ xm.vstd vec_B
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_s8/vect_s8_is_negative.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_s8/vect_s8_is_negative.S
@@ -66,10 +66,10 @@ la t3, vpu_vec_0xC1
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_add.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_add.S
@@ -132,18 +132,18 @@ FNAME_S32:
 
 .global vect_s16_add
 .type vect_s16_add,@function
-.set vect_s16_add.nstackwords,NSTACKWORDS;  .global vect_s16_add.nstackwords
-.set vect_s16_add.maxcores,1;               .global vect_s16_add.maxcores
-.set vect_s16_add.maxtimers,0;              .global vect_s16_add.maxtimers
-.set vect_s16_add.maxchanends,0;            .global vect_s16_add.maxchanends
+.resource_const vect_s16_add, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s16_add, "tail_callees"
+.resource_list_empty vect_s16_add, "callees"
+.resource_list_empty vect_s16_add, "parallel_callees"
 .size vect_s16_add, .L_func_end_s16 - vect_s16_add
 
 .global vect_s32_add
 .type vect_s32_add,@function
-.set vect_s32_add.nstackwords,NSTACKWORDS;  .global vect_s32_add.nstackwords
-.set vect_s32_add.maxcores,1;               .global vect_s32_add.maxcores
-.set vect_s32_add.maxtimers,0;              .global vect_s32_add.maxtimers
-.set vect_s32_add.maxchanends,0;            .global vect_s32_add.maxchanends
+.resource_const vect_s32_add, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s32_add, "tail_callees"
+.resource_list_empty vect_s32_add, "callees"
+.resource_list_empty vect_s32_add, "parallel_callees"
 .size vect_s32_add, .L_func_end_s32 - vect_s32_add
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_headroom.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_headroom.S
@@ -61,10 +61,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end_s16 - FUNCTION_NAME
 
 
@@ -119,10 +119,10 @@ FUNCTION_NAME:
 
 .globl FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS;     .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;                  .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;                 .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;               .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end_s32 - FUNCTION_NAME
 
 #undef FUNCTION_NAME

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_rect.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_rect.S
@@ -119,18 +119,18 @@ vect_s32_rect:
 
 .global vect_s16_rect
 .type vect_s16_rect,@function
-.set vect_s16_rect.nstackwords,NSTACKWORDS;  .global vect_s16_rect.nstackwords
-.set vect_s16_rect.maxcores,1;               .global vect_s16_rect.maxcores
-.set vect_s16_rect.maxtimers,0;              .global vect_s16_rect.maxtimers
-.set vect_s16_rect.maxchanends,0;            .global vect_s16_rect.maxchanends
+.resource_const vect_s16_rect, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s16_rect, "tail_callees"
+.resource_list_empty vect_s16_rect, "callees"
+.resource_list_empty vect_s16_rect, "parallel_callees"
 .size vect_s16_rect, .L_func_end_s16 - vect_s16_rect
 
 .global vect_s32_rect
 .type vect_s32_rect,@function
-.set vect_s32_rect.nstackwords,NSTACKWORDS;  .global vect_s32_rect.nstackwords
-.set vect_s32_rect.maxcores,1;               .global vect_s32_rect.maxcores
-.set vect_s32_rect.maxtimers,0;              .global vect_s32_rect.maxtimers
-.set vect_s32_rect.maxchanends,0;            .global vect_s32_rect.maxchanends
+.resource_const vect_s32_rect, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s32_rect, "tail_callees"
+.resource_list_empty vect_s32_rect, "callees"
+.resource_list_empty vect_s32_rect, "parallel_callees"
 .size vect_s32_rect, .L_func_end_s32 - vect_s32_rect
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_add_scalar.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_add_scalar.S
@@ -98,10 +98,10 @@ FUNCTION_NAME:
 
 .global FUNCTION_NAME
 .type FUNCTION_NAME,@function
-.set FUNCTION_NAME.nstackwords,NSTACKWORDS; .global FUNCTION_NAME.nstackwords
-.set FUNCTION_NAME.maxcores,1;              .global FUNCTION_NAME.maxcores
-.set FUNCTION_NAME.maxtimers,0;             .global FUNCTION_NAME.maxtimers
-.set FUNCTION_NAME.maxchanends,0;           .global FUNCTION_NAME.maxchanends
+.resource_const FUNCTION_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNCTION_NAME, "tail_callees"
+.resource_list_empty FUNCTION_NAME, "callees"
+.resource_list_empty FUNCTION_NAME, "parallel_callees"
 .size FUNCTION_NAME, .L_func_end - FUNCTION_NAME
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
@@ -35,10 +35,10 @@ FUNC_NAME:
 
 .global FUNC_NAME
 .type FUNC_NAME,@function
-.set FUNC_NAME.nstackwords,NSTACKWORDS;  .global FUNC_NAME.nstackwords
-.set FUNC_NAME.maxcores,1;               .global FUNC_NAME.maxcores
-.set FUNC_NAME.maxtimers,0;              .global FUNC_NAME.maxtimers
-.set FUNC_NAME.maxchanends,0;            .global FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s32 - FUNC_NAME
 #undef FUNC_NAME
   
@@ -66,10 +66,10 @@ FUNC_NAME:
 
 .global FUNC_NAME
 .type FUNC_NAME,@function
-.set FUNC_NAME.nstackwords,NSTACKWORDS;  .global FUNC_NAME.nstackwords
-.set FUNC_NAME.maxcores,1;               .global FUNC_NAME.maxcores
-.set FUNC_NAME.maxtimers,0;              .global FUNC_NAME.maxtimers
-.set FUNC_NAME.maxchanends,0;            .global FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s16 - FUNC_NAME
 #undef FUNC_NAME
   
@@ -97,10 +97,10 @@ FUNC_NAME:
 
 .global FUNC_NAME
 .type FUNC_NAME,@function
-.set FUNC_NAME.nstackwords,NSTACKWORDS;  .global FUNC_NAME.nstackwords
-.set FUNC_NAME.maxcores,1;               .global FUNC_NAME.maxcores
-.set FUNC_NAME.maxtimers,0;              .global FUNC_NAME.maxtimers
-.set FUNC_NAME.maxchanends,0;            .global FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s8 - FUNC_NAME
 #undef FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
@@ -185,6 +185,12 @@ vect_sXX_max_elementwise:
 
 .L_end_sXX:
 
+.resource_const vect_sXX_max_elementwise, "stack_frame_bytes", 0 ;\
+.resource_list_empty vect_sXX_max_elementwise, "tail_callees" ;\
+.resource_list_empty vect_sXX_max_elementwise, "callees" ;\
+.resource_list_empty vect_sXX_max_elementwise, "parallel_callees" ;\
+.size vect_sXX_max_elementwise, . - vect_sXX_max_elementwise
+
 
 #endif //defined(__VX4B__)
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
@@ -37,7 +37,7 @@ FUNC_NAME:
 .type FUNC_NAME,@function
 .resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .resource_list_empty FUNC_NAME, "tail_callees"
-.resource_list_empty FUNC_NAME, "callees"
+.resource_list_add   FUNC_NAME, "callees", vect_sXX_max_elementwise
 .resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s32 - FUNC_NAME
 #undef FUNC_NAME
@@ -68,7 +68,7 @@ FUNC_NAME:
 .type FUNC_NAME,@function
 .resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .resource_list_empty FUNC_NAME, "tail_callees"
-.resource_list_empty FUNC_NAME, "callees"
+.resource_list_add   FUNC_NAME, "callees", vect_sXX_max_elementwise
 .resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s16 - FUNC_NAME
 #undef FUNC_NAME
@@ -99,7 +99,7 @@ FUNC_NAME:
 .type FUNC_NAME,@function
 .resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .resource_list_empty FUNC_NAME, "tail_callees"
-.resource_list_empty FUNC_NAME, "callees"
+.resource_list_add   FUNC_NAME, "callees", vect_sXX_max_elementwise
 .resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s8 - FUNC_NAME
 #undef FUNC_NAME
@@ -185,10 +185,10 @@ vect_sXX_max_elementwise:
 
 .L_end_sXX:
 
-.resource_const vect_sXX_max_elementwise, "stack_frame_bytes", 0 ;\
-.resource_list_empty vect_sXX_max_elementwise, "tail_callees" ;\
-.resource_list_empty vect_sXX_max_elementwise, "callees" ;\
-.resource_list_empty vect_sXX_max_elementwise, "parallel_callees" ;\
+.resource_const vect_sXX_max_elementwise, "stack_frame_bytes", 0
+.resource_list_empty vect_sXX_max_elementwise, "tail_callees"
+.resource_list_empty vect_sXX_max_elementwise, "callees"
+.resource_list_empty vect_sXX_max_elementwise, "parallel_callees"
 .size vect_sXX_max_elementwise, . - vect_sXX_max_elementwise
 
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_max_elementwise.S
@@ -183,8 +183,6 @@ vect_sXX_max_elementwise:
     mv a0, t3
     ret 
 
-.L_end_sXX:
-
 .resource_const vect_sXX_max_elementwise, "stack_frame_bytes", 0
 .resource_list_empty vect_sXX_max_elementwise, "tail_callees"
 .resource_list_empty vect_sXX_max_elementwise, "callees"

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_min_elementwise.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_min_elementwise.S
@@ -37,7 +37,7 @@ FUNC_NAME:
 .type FUNC_NAME,@function
 .resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .resource_list_empty FUNC_NAME, "tail_callees"
-.resource_list_empty FUNC_NAME, "callees"
+.resource_list_add   FUNC_NAME, "callees", vect_sXX_min_elementwise
 .resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s32 - FUNC_NAME
 #undef FUNC_NAME
@@ -68,7 +68,7 @@ FUNC_NAME:
 .type FUNC_NAME,@function
 .resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .resource_list_empty FUNC_NAME, "tail_callees"
-.resource_list_empty FUNC_NAME, "callees"
+.resource_list_add   FUNC_NAME, "callees", vect_sXX_min_elementwise
 .resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s16 - FUNC_NAME
 #undef FUNC_NAME
@@ -99,7 +99,7 @@ FUNC_NAME:
 .type FUNC_NAME,@function
 .resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
 .resource_list_empty FUNC_NAME, "tail_callees"
-.resource_list_empty FUNC_NAME, "callees"
+.resource_list_add   FUNC_NAME, "callees", vect_sXX_min_elementwise
 .resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s8 - FUNC_NAME
 #undef FUNC_NAME
@@ -183,9 +183,11 @@ vect_sXX_min_elementwise:
     mv a0, t3
     ret 
 
-
-.L_end_sXX:
-
+.resource_const vect_sXX_min_elementwise, "stack_frame_bytes", 0
+.resource_list_empty vect_sXX_min_elementwise, "tail_callees"
+.resource_list_empty vect_sXX_min_elementwise, "callees"
+.resource_list_empty vect_sXX_min_elementwise, "parallel_callees"
+.size vect_sXX_min_elementwise, . - vect_sXX_min_elementwise
 
 #endif //defined(__VX4B__)
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_min_elementwise.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sXX_min_elementwise.S
@@ -35,10 +35,10 @@ FUNC_NAME:
 
 .global FUNC_NAME
 .type FUNC_NAME,@function
-.set FUNC_NAME.nstackwords,NSTACKWORDS;  .global FUNC_NAME.nstackwords
-.set FUNC_NAME.maxcores,1;               .global FUNC_NAME.maxcores
-.set FUNC_NAME.maxtimers,0;              .global FUNC_NAME.maxtimers
-.set FUNC_NAME.maxchanends,0;            .global FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s32 - FUNC_NAME
 #undef FUNC_NAME
   
@@ -66,10 +66,10 @@ FUNC_NAME:
 
 .global FUNC_NAME
 .type FUNC_NAME,@function
-.set FUNC_NAME.nstackwords,NSTACKWORDS;  .global FUNC_NAME.nstackwords
-.set FUNC_NAME.maxcores,1;               .global FUNC_NAME.maxcores
-.set FUNC_NAME.maxtimers,0;              .global FUNC_NAME.maxtimers
-.set FUNC_NAME.maxchanends,0;            .global FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s16 - FUNC_NAME
 #undef FUNC_NAME
   
@@ -97,10 +97,10 @@ FUNC_NAME:
 
 .global FUNC_NAME
 .type FUNC_NAME,@function
-.set FUNC_NAME.nstackwords,NSTACKWORDS;  .global FUNC_NAME.nstackwords
-.set FUNC_NAME.maxcores,1;               .global FUNC_NAME.maxcores
-.set FUNC_NAME.maxtimers,0;              .global FUNC_NAME.maxtimers
-.set FUNC_NAME.maxchanends,0;            .global FUNC_NAME.maxchanends
+.resource_const FUNC_NAME, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty FUNC_NAME, "tail_callees"
+.resource_list_empty FUNC_NAME, "callees"
+.resource_list_empty FUNC_NAME, "parallel_callees"
 .size FUNC_NAME, .L_end_s8 - FUNC_NAME
 #undef FUNC_NAME
 

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_set.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_set.S
@@ -110,24 +110,24 @@ vect_complex_s32_set:
 
 .globl vect_s16_set
 .type vect_s16_set,@function
-.set vect_s16_set.nstackwords,NSTACKWORDS;  .global vect_s16_set.nstackwords; 
-.set vect_s16_set.maxcores,1;               .global vect_s16_set.maxcores; 
-.set vect_s16_set.maxtimers,0;              .global vect_s16_set.maxtimers; 
-.set vect_s16_set.maxchanends,0;            .global vect_s16_set.maxchanends; 
+.resource_const vect_s16_set, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s16_set, "tail_callees"
+.resource_list_empty vect_s16_set, "callees"
+.resource_list_empty vect_s16_set, "parallel_callees"
 
 .globl vect_s32_set
 .type vect_s32_set,@function
-.set vect_s32_set.nstackwords,NSTACKWORDS;  .global vect_s32_set.nstackwords; 
-.set vect_s32_set.maxcores,1;               .global vect_s32_set.maxcores; 
-.set vect_s32_set.maxtimers,0;              .global vect_s32_set.maxtimers; 
-.set vect_s32_set.maxchanends,0;            .global vect_s32_set.maxchanends; 
+.resource_const vect_s32_set, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s32_set, "tail_callees"
+.resource_list_empty vect_s32_set, "callees"
+.resource_list_empty vect_s32_set, "parallel_callees"
 
 .globl vect_complex_s32_set
 .type vect_complex_s32_set,@function
-.set vect_complex_s32_set.nstackwords,NSTACKWORDS;  .global vect_complex_s32_set.nstackwords; 
-.set vect_complex_s32_set.maxcores,1;               .global vect_complex_s32_set.maxcores; 
-.set vect_complex_s32_set.maxtimers,0;              .global vect_complex_s32_set.maxtimers; 
-.set vect_complex_s32_set.maxchanends,0;            .global vect_complex_s32_set.maxchanends; 
+.resource_const vect_complex_s32_set, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_complex_s32_set, "tail_callees"
+.resource_list_empty vect_complex_s32_set, "callees"
+.resource_list_empty vect_complex_s32_set, "parallel_callees"
 
 
 #endif //defined(__VX4B__)

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_shl.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_shl.S
@@ -153,17 +153,17 @@ vect_s32_shl:
 
 .globl vect_s16_shl
 .type vect_s16_shl,@function
-.set vect_s16_shl.nstackwords,NSTACKWORDS;  .global vect_s16_shl.nstackwords
-.set vect_s16_shl.maxcores,1;               .global vect_s16_shl.maxcores
-.set vect_s16_shl.maxtimers,0;              .global vect_s16_shl.maxtimers
-.set vect_s16_shl.maxchanends,0;            .global vect_s16_shl.maxchanends
+.resource_const vect_s16_shl, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s16_shl, "tail_callees"
+.resource_list_empty vect_s16_shl, "callees"
+.resource_list_empty vect_s16_shl, "parallel_callees"
 
 .globl vect_s32_shl
 .type vect_s32_shl,@function
-.set vect_s32_shl.nstackwords,NSTACKWORDS;  .global vect_s32_shl.nstackwords
-.set vect_s32_shl.maxcores,1;               .global vect_s32_shl.maxcores
-.set vect_s32_shl.maxtimers,0;              .global vect_s32_shl.maxtimers
-.set vect_s32_shl.maxchanends,0;            .global vect_s32_shl.maxchanends
+.resource_const vect_s32_shl, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s32_shl, "tail_callees"
+.resource_list_empty vect_s32_shl, "callees"
+.resource_list_empty vect_s32_shl, "parallel_callees"
 
 
 #endif //defined(__VX4B__)

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_shl.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_shl.S
@@ -24,10 +24,6 @@ headroom_t vect_s32_shl(
 
 #define NSTACKWORDS     (8+2+2+4)
 
-#define FUNCTION_NAME   shl_vect
-#define FNAME_S16       CAT(FUNCTION_NAME, _s16)
-#define FNAME_S32       CAT(FUNCTION_NAME, _s32)
-
 #define STACK_TMP_VEC       (NSTACKWORDS-10)
 
 #define a           a0

--- a/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sub.S
+++ b/lib_xcore_math/src/arch/vx4b/vect_sXX/vect_sub.S
@@ -131,18 +131,18 @@ vect_s32_sub:
 
 .global vect_s16_sub
 .type vect_s16_sub,@function
-.set vect_s16_sub.nstackwords,NSTACKWORDS;  .global vect_s16_sub.nstackwords
-.set vect_s16_sub.maxcores,1;               .global vect_s16_sub.maxcores
-.set vect_s16_sub.maxtimers,0;              .global vect_s16_sub.maxtimers
-.set vect_s16_sub.maxchanends,0;            .global vect_s16_sub.maxchanends
+.resource_const vect_s16_sub, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s16_sub, "tail_callees"
+.resource_list_empty vect_s16_sub, "callees"
+.resource_list_empty vect_s16_sub, "parallel_callees"
 .size vect_s16_sub, .L_func_end_s16 - vect_s16_sub
 
 .global vect_s32_sub
 .type vect_s32_sub,@function
-.set vect_s32_sub.nstackwords,NSTACKWORDS;  .global vect_s32_sub.nstackwords
-.set vect_s32_sub.maxcores,1;               .global vect_s32_sub.maxcores
-.set vect_s32_sub.maxtimers,0;              .global vect_s32_sub.maxtimers
-.set vect_s32_sub.maxchanends,0;            .global vect_s32_sub.maxchanends
+.resource_const vect_s32_sub, "stack_frame_bytes", (NSTACKWORDS)*4
+.resource_list_empty vect_s32_sub, "tail_callees"
+.resource_list_empty vect_s32_sub, "callees"
+.resource_list_empty vect_s32_sub, "parallel_callees"
 .size vect_s32_sub, .L_func_end_s32 - vect_s32_sub
 
     


### PR DESCRIPTION
This fixes the '.set' primitives that are no longer relevant in the LLVM RISCV toolchain, and replaces them with the appropriate .resource_list primitives. 